### PR TITLE
Change errors to 403 Forbidden

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,28 +4,37 @@ else
   var config_path = './config.js';
 
 var config = require(config_path);
+var strings = require('./strings.js');
 
 var restify = require('restify');
-var util = require('util');
+
+var FORBIDDEN_CODE = 403;
+var FORBIDDEN_ERROR = {error: {code: 'FORBIDDEN',
+                               message: strings.FORBIDDEN}};
+function FORBIDDEN_CALLBACK(req, res, next) {
+  res.send(FORBIDDEN_CODE, FORBIDDEN_ERROR);
+}
 
 var server = restify.createServer();
 server.use(restify.queryParser()); // Allows us to access req.query
 server.name = 'Hook to Deploy';
 
 server.get('/hook/:hook_name', function(req, res, next) {
+  if (!(req.params.hasOwnProperty('hook_name')) ||            // no hook name provided or
+      !(config.hooks.hasOwnProperty(req.params.hook_name))) { // hook does not exist
+    res.send(FORBIDDEN_CODE, FORBIDDEN_ERROR);
+  }
+
   var hook = config.hooks[req.params.hook_name];
-  if (!(req.query.hasOwnProperty('key'))) {
-    var no_key_error = util.format('Missing key for hook \'%s\'. ' +
-                                   'Pass in the key as a query string (?key=YOUR_KEY_HERE).',
-                                   req.params.hook_name);
-    res.send(400, {error: {code: 'MISSING_KEY', message: no_key_error}});
-  } else if (req.query.key !== hook.key) {
-    var bad_key_error = util.format('Key for hook \'%s\' is incorrect.', req.params.hook_name);
-    res.send(403, {error: {code: 'INCORRECT_KEY', message: bad_key_error}});
+  if (!(req.query.hasOwnProperty('key')) ||                   // no key provided or
+      req.query.key !== hook.key) {                           // hook key is incorrect
+    res.send(FORBIDDEN_CODE, FORBIDDEN_ERROR);
   } else {
     hook.action(req, res); // Hook must handle res.send()
   }
 });
+server.on('NotFound', FORBIDDEN_CALLBACK);
+server.on('MethodNotAllowed', FORBIDDEN_CALLBACK);
 
 server.listen(config.port, function() {
   console.log('%s listening on %s', server.name, server.url);

--- a/strings.js
+++ b/strings.js
@@ -1,0 +1,5 @@
+var FORBIDDEN = 'Forbidden';
+
+module.exports = {
+  FORBIDDEN: FORBIDDEN
+};

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -12,20 +12,43 @@ var client = restify.createJsonClient({
   url: 'http://localhost:8080'
 });
 
+function GET_FORBIDDEN(path, done) {
+  client.get(path, function(err, req, res, data) {
+    should.exist(err);
+    res.statusCode.should.eql(403);
+    data.error.code.should.eql('FORBIDDEN');
+    done();
+  });
+}
+
 describe('key correctness:', function() {
   it('should send a 200 OK response for correct keys', function(done) {
     client.get('/hook/project_one?key=p1_key', function(err, req, res, data) {
       should.not.exist(err);
       res.statusCode.should.eql(200);
+      data.success.should.eql('hello, this is project_one');
       done();
     });
   });
-  it('should send a 403 Forbidden server error for incorrect keys', function(done) {
-    client.get('/hook/project_one?key=BAD_KEY', function(err, req, res, data) {
-      should.exist(err);
-      res.statusCode.should.eql(403);
-      data.error.code.should.eql('INCORRECT_KEY');
-      done();
-    });
+  it('should send a 403 Forbidden response for incorrect keys', function(done) {
+    GET_FORBIDDEN('/hook/project_one?key=BAD_KEY', done);
+  });
+  it('should send a 403 Forbidden response for missing keys', function(done) {
+    GET_FORBIDDEN('/hook/project_one', done);
+  });
+});
+
+describe('bad routes:', function() {
+  it('should send a 403 Forbidden response for nonexistent routes', function(done) {
+    GET_FORBIDDEN('/DOES_NOT_EXIST', done);
+  });
+  it('should send a 403 Forbidden response for nonexistent routes with a key', function(done) {
+    GET_FORBIDDEN('/', done);
+  });
+  it('should send a 403 Forbidden response for the root route', function(done) {
+    GET_FORBIDDEN('/', done);
+  });
+  it('should send a 403 Forbidden response for the root route with a key', function(done) {
+    GET_FORBIDDEN('/', done);
   });
 });

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -52,3 +52,13 @@ describe('bad routes:', function() {
     GET_FORBIDDEN('/', done);
   });
 });
+
+describe('wrong methods:', function() {
+  it('should send a 403 Forbidden response for using invalid methods on GET-only routes', function(done) {
+    client.del('/hook/project_one?key=p1_key', function(err, req, res) {
+      should.exist(err);
+      res.statusCode.should.eql(403);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
403 Forbidden because we don't want people poking around the server—this isn't supposed to be a public interface of any kind and we won't dignify them with a response unless they're giving us the proper key.

Closes #2.
